### PR TITLE
Fix Instrumented tests using Gradle bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,6 @@ dependencies {
     androidTestImplementation "androidx.test:core-ktx:1.3.0"
     androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestUtil 'androidx.test:orchestrator:1.4.0'
+    androidTestUtil 'androidx.test:orchestrator:1.4.1'
     debugImplementation "androidx.fragment:fragment-testing:1.3.3"
 }


### PR DESCRIPTION
"Run Android instrumented tests using Gradle" option was ignored because this module type is not supported yet.
My pull request can resolve this issue.