### PR TITLE
Fixed an issue when running tests in sequence

### DIFF
--- a/app/src/androidTest/java/com/example/forage/PersistenceInstrumentationTests.kt
+++ b/app/src/androidTest/java/com/example/forage/PersistenceInstrumentationTests.kt
@@ -50,6 +50,7 @@ class PersistenceInstrumentationTests {
     fun new_forageable_is_displayed_in_list() {
         onView(withText("Name")).check(matches(isDisplayed()))
         onView(withText("Address")).check(matches(isDisplayed()))
+        delete_new_forageable()
     }
 
     @Test
@@ -59,6 +60,7 @@ class PersistenceInstrumentationTests {
         onView(withText("Address")).check(matches(isDisplayed()))
         onView(withText(("Currently out of season"))).check(matches(isDisplayed()))
         onView(withText("Notes")).check(matches(isDisplayed()))
+        delete_new_forageable()
     }
 
     @Test


### PR DESCRIPTION
If you run the tests sequentially, several entities with the same name will be created. Because of this, all tests except the first one will throw an exception.